### PR TITLE
Enable Network Access

### DIFF
--- a/io.github.CyberTimon.RapidRAW.yml
+++ b/io.github.CyberTimon.RapidRAW.yml
@@ -13,6 +13,7 @@ finish-args:
   - --socket=fallback-x11
   - --device=dri
   - --share=ipc
+  - --share=network
 
 build-options:
   append-path: /usr/lib/sdk/node24/bin:/usr/lib/sdk/rust-stable/bin


### PR DESCRIPTION
This enables access to the network for the Flatpak in order to fix the community presets functionality. These are updated from a GitHub repository and thus require access to the network to become available.